### PR TITLE
Fix crash when user already exists and fix attr create call

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -479,7 +479,6 @@ function createCustomAttr(thisAttr, customName, accessToken) {
                 "args": {
                   "name":"${thisAttr.name}"
                 },
-                "ruleId": "11",
                 "datatype":"${thisAttr.type}",
                 "name":"${thisAttr.name}",
                 "description": "Created for Demo App",
@@ -488,7 +487,7 @@ function createCustomAttr(thisAttr, customName, accessToken) {
                   "name":"${customName}",
                   "scimName":"${thisAttr.name}"},
                   "scope":"tenant",
-                  "sourceType":"rule",
+                  "sourceType":"schema",
                   "tags":[]
                 }`
 

--- a/routes/open-account.js
+++ b/routes/open-account.js
@@ -166,7 +166,14 @@ router.post('/car', function(req, res, next) {
               }
               else{
                 var userId = body.id;
-                var customAttributes = (typeof req.session.userprofile["urn:ietf:params:scim:schemas:extension:ibm:2.0:User"]["customAttributes"] != 'undefined') ? req.session.userprofile["urn:ietf:params:scim:schemas:extension:ibm:2.0:User"]["customAttributes"] : false;
+                var customAttributes =
+                  typeof req.session.userprofile != "undefined" && req.session.userprofile[
+                    "urn:ietf:params:scim:schemas:extension:ibm:2.0:User"
+                  ]["customAttributes"] != "undefined"
+                    ? req.session.userprofile[
+                        "urn:ietf:params:scim:schemas:extension:ibm:2.0:User"
+                      ]["customAttributes"]
+                    : false;
                 console.log("Custom attributes?", customAttributes)
                 var quoteCount = (!customAttributes) ? 1 : parseInt((_.filter(customAttributes,{ 'name': 'quoteCount' }))[0].values.toString())+1;
                 console.log("This is the current quoteCount:", quoteCount)


### PR DESCRIPTION
Currently when quote generated for an e-mail address that already exists as an account, server crashes and doesn't respond.  I have added logic to check for this and to continue.