### PR TITLE
Hacky Innovation Showcase demo changes

### DIFF
--- a/ci-templates/templates/authsvc/basicldapuser_login/default/default/page.html
+++ b/ci-templates/templates/authsvc/basicldapuser_login/default/default/page.html
@@ -62,7 +62,7 @@
 					</div>
           <p>OR</p>
         </div>
-		<div class="alert warning">
+		<div class="alert warning" style="display: none">
             <span class="closebtn" onclick="this.parentElement.style.display='none';">&times;</span>
             @ERROR_MESSAGE@
           </div>

--- a/ci-templates/templates/profile/registration/default/default/page.html
+++ b/ci-templates/templates/profile/registration/default/default/page.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<base href='/' />
+	<meta http-equiv='content-type' content='text/html; charset=UTF-8' />
+	<title>TrustMeInsurance Login</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<link rel="apple-touch-icon" sizes="180x180" href="DEMO_APPLICATION_URL/favicon/apple-touch-icon.png">
+	<link rel="icon" type="image/png" sizes="32x32" href="DEMO_APPLICATION_URL/favicon/favicon-32x32.png">
+	<link rel="icon" type="image/png" sizes="16x16" href="DEMO_APPLICATION_URL/favicon/favicon-16x16.png">
+	<link rel="manifest" href="DEMO_APPLICATION_URL/favicon/site.webmanifest">
+	<link rel="mask-icon" href="DEMO_APPLICATION_URL/favicon/safari-pinned-tab.svg" color="#7a6f6f">
+	<link rel="shortcut icon" href="DEMO_APPLICATION_URL/f8avicon/favicon.ico">
+	<meta name="msapplication-TileColor" content="#ffffff">
+	<meta name="msapplication-config" content="DEMO_APPLICATION_URL/favicon/browserconfig.xml">
+	<meta name="theme-color" content="#ffffff">
+
+	<link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
+	<link href="DEMO_APPLICATION_URL/stylesheets/style.css" rel="stylesheet" type="text/css">
+	<link href="DEMO_APPLICATION_URL/stylesheets/social.css" rel="stylesheet" type="text/css">
+	<link href="DEMO_APPLICATION_URL/stylesheets/overrides.css" rel="stylesheet" type="text/css">
+	<link rel='stylesheet' href='/usc/css/stateless.css'>
+	<link rel='stylesheet' href='/profile/static/registration.css?version=@REGISTRATION_VERSION@'>
+	<link rel='stylesheet' href='/template/v1.0/static/theme.css?themeId=@THEME_ID@' />
+</head>
+
+<body class="insurance-page gary-bg" onload="setAction()" style="background-image: none">
+	<div class="overlay-background">
+
+		<div class="overlay-content login-wrap">
+
+			<div class="overlay-logo">
+				<a href="DEMO_APPLICATION_URL/"><img src="DEMO_APPLICATION_URL/images/insurance_logo.svg"></a>
+			</div>
+
+
+			<div class='registration'>
+				@REGISTRATION_FORM@
+			</div>
+
+		</div>
+
+	</div>
+	<!-- Do not remove, may affect functionality -->
+	<div id="loader" class="bx--loading-overlay">
+		<div data-loading class="bx--loading">
+			<svg class="bx--loading__svg" viewBox="-75 -75 150 150">
+				<title>Loading</title>
+				<circle class="bx--loading__stroke" cx="0" cy="0" r="37.5" />
+			</svg>
+		</div>
+	</div>
+	<!-- Do not remove, may affect functionality -->
+	<script type="text/javascript" src="/profile/static/carbon-components.min.js"></script>
+	<script type="text/javascript" src="/profile/static/registration.js?version=@REGISTRATION_VERSION@"></script>
+	<script type="text/javascript" src="/usc/js/ieCheck.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.2/jquery.min.js"></script>
+	<script src="DEMO_APPLICATION_URL/javascripts/init.js"></script>
+</body>
+
+</html>

--- a/ci-templates/templates/profile/registration/metadata.json
+++ b/ci-templates/templates/profile/registration/metadata.json
@@ -1,0 +1,48 @@
+{
+   "contentMaxSize": 100,
+   "description": "A Page to contain the generated User Registration Flow.",
+   "id": {
+      "component": "profile",
+      "name": "registration",
+      "revision": 1
+   },
+   "isServiceTemplate": false,
+   "parameters": {
+      "optional": [
+         {
+            "default": null,
+            "description": "The ID of the registered template theme.",
+            "key": "@THEME_ID@"
+         },
+         {
+            "default": null,
+            "description": "The final part of the flow URL, the endpoint where the flow is hosted.",
+            "key": "@FLOW_URL_NAME@"
+         },
+         {
+            "default": null,
+            "description": "The HTML that contains the header of the web page. This code can be modified by customizing the header.html common template.",
+            "key": "@PAGE_HEADER@"
+         },
+         {
+            "default": null,
+            "description": "The HTML that contains the footer of the page. This code can be modified by customizing the footer.html common template.",
+            "key": "@PAGE_FOOTER@"
+         }
+      ],
+      "required": [
+         {
+            "description": "Controls the placement of the generated registration form fields and action button. Begins with the first Step.",
+            "key": "@REGISTRATION_FORM@"
+         },
+         {
+            "description": "The browser tab page title for the registration form.",
+            "key": "@REGISTRATION_TITLE@"
+         },
+         {
+            "description": "The IBM release version of the generated registration form.",
+            "key": "@REGISTRATION_VERSION@"
+         }
+      ]
+   }
+}

--- a/layout.hbs
+++ b/layout.hbs
@@ -36,7 +36,7 @@
               </div>
         <div class="header-right">
          
-          <a href="/account-claim" class="">Claim your account</a>
+          <a href="https://ccmurray-profile.dev.verify.ibmcloudsecurity.com/register/trustme" class="">Sign-up</a>
           <a href="/open-account" class="open-btn">Get a quote</a>
           {{#unless loggedIn}}<a href="/login" class="login-btn">Login</a>{{/unless}}
           {{#if loggedIn}}<a href="/app/profile" class="login-btn" style="margin: 0 10px;">Profile</a>

--- a/views/layout.hbs
+++ b/views/layout.hbs
@@ -36,7 +36,7 @@
               </div>
         <div class="header-right">
          
-          <a href="/account-claim" class="">Claim your account</a>
+          <a href="https://ccmurray-profile.dev.verify.ibmcloudsecurity.com/register/trustme" class="">Sign-up</a>
           <a href="/open-account" class="open-btn">Get a quote</a>
           {{#unless loggedIn}}<a href="/login" class="login-btn">Login</a>{{/unless}}
           {{#if loggedIn}}<a href="/app/profile" class="login-btn" style="margin: 0 10px;">Profile</a>


### PR DESCRIPTION
I recommend against just merging these changes. I made these changes very quickly in order to get our demo to work, and I am sure there is a much better way to integrate what we wanted here.

Things that were changed:
* Force hid the yellow error notification box on the login page (this should likely be done through CSS instead of style= directly on the element)
* Added Registration template pages (based on login page). This is missing the copyright footer.
* Changed the home page link from "Claim your account" to "Sign-up" which links to MY TENANT. This 100% needs to be changed to use whatever tenant is configured for the project.